### PR TITLE
Create travis-ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: php
+
+php:
+  - '5.6'
+  - '7.0'
+  - hhvm
+  - nightly
+
+before_script:
+  - cp .env.example .env
+  - mysql -e 'create database homestead_test;'
+  - composer self-update
+  - composer install --no-interaction
+  - php artisan key:generate
+
+script:
+  - vendor/bin/phpunit


### PR DESCRIPTION
Setup travis-ci service config

 `kyslik/column-sortable` 5.1.1 and `laravel/framework` v5.3.8 requires php >=5.6.4
So other enviroments than php >=5.6 are not compatible 

related issue https://github.com/odirleiborgert/borgert-cms/issues/4 